### PR TITLE
Remove explicit enable of the ose 3.9 yum repo

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -5,8 +5,8 @@ LABEL maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
       version="v0.15.2" \
       architecture=x86_64
 
-RUN yum-config-manager --enable rhel-7-server-ose-3.9-rpms && \
-    yum install -y prometheus-node-exporter && \
+# The appropriate yum repos are enabled at build time by the CI system
+RUN yum install -y prometheus-node-exporter && \
     yum clean all
 
 USER       nobody


### PR DESCRIPTION
The appropriate yum repos are enabled at build time using the atomic-reactor tooling