### PR TITLE
Install promu package for OCP multistage builds

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -2,7 +2,8 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 
 WORKDIR /go/src/github.com/prometheus/node_exporter
 COPY . .
-RUN make build
+ENV BUILD_PROMU=false
+RUN yum install -y prometheus-promu && make build && yum clean all
 
 FROM  registry.svc.ci.openshift.org/ocp/4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \


### PR DESCRIPTION
Similar to https://github.com/openshift/prometheus/pull/21:

> We need `promu` to build Prometheus but we should use the promu package instead of the upstream version because 1) we're not allowed to download stuff from the outside and 2) this promu version generates proper binaries for OCP (eg dynamically linked with glibc).

cc @sosiouxme 