### PR TITLE
unify Dockerfile naming and bring in upstream Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+ARG ARCH="amd64"
+ARG OS="linux"
+FROM quay.io/prometheus/busybox-${OS}-${ARCH}:glibc
+LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-WORKDIR /go/src/github.com/prometheus/node_exporter
-COPY . .
-RUN make build
-
-FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \
-      io.k8s.description="Prometheus exporter for machine metrics" \
-      io.openshift.tags="prometheus,monitoring" \
-      maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
-
-COPY --from=builder /go/src/github.com/prometheus/node_exporter/node_exporter /bin/node_exporter
+ARG ARCH="amd64"
+ARG OS="linux"
+COPY .build/${OS}-${ARCH}/node_exporter /bin/node_exporter
 
 EXPOSE      9100
 USER        nobody

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,15 +1,14 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
 WORKDIR /go/src/github.com/prometheus/node_exporter
 COPY . .
-ENV BUILD_PROMU=false
-RUN yum install -y prometheus-promu && make build && yum clean all
+RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build
 
-FROM  registry.svc.ci.openshift.org/ocp/4.0:base
+FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \
       io.k8s.description="Prometheus exporter for machine metrics" \
       io.openshift.tags="prometheus,monitoring" \
-      maintainer="OpenShift Development <dev@lists.openshift.redhat.com>"
+      maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 COPY --from=builder /go/src/github.com/prometheus/node_exporter/node_exporter /bin/node_exporter
 


### PR DESCRIPTION
Similar to openshift/prometheus#34

- `mv Dockerfile.rhel Dockerfile.ocp`
- Bring in upstream Dockerfile (just to keep it clean)

CI will fail as it needs openshift/release#4235 first.