### PR TITLE
text_collectors: Add a virtualization metric series from virt-what

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -12,6 +12,9 @@ LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \
 
 COPY --from=builder /go/src/github.com/prometheus/node_exporter/node_exporter /bin/node_exporter
 
+RUN yum install -y virt-what && yum clean all && rm -rf /var/cache/*
+COPY text_collectors/virt.sh /node_exporter/collectors/init/
+
 EXPOSE      9100
 USER        nobody
 ENTRYPOINT  [ "/bin/node_exporter" ]

--- a/text_collectors/virt.sh
+++ b/text_collectors/virt.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+#
+# Description: Expose metrics for detected platform virtualization
+# Dependencies: virt-what (packages)
+#
+# The script creates one metric series for each detected virtualization platform
+# reported by virt-what.
+#
+# Author: Clayton Coleman <smarterclayton@gmail.com>
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+v="${TMPDIR}/virt.working"
+rm -f "${v}" || true
+touch "${v}"
+if [ -x /usr/sbin/virt-what ]
+then
+  for platform in $( virt-what ); do
+    if [[ -z "${platform}" ]]; then
+      continue
+    fi
+    echo "# HELP virt_platform reports one series per detected virtualization type" >"${v}"
+    echo "# TYPE virt_platform gauge" >"${v}"
+    echo "virt_platform{type=\"${platform}\"} 1" >"${v}"
+  done
+fi
+mv "${v}" virt.prom


### PR DESCRIPTION
`virt-what` performs heuristic detection within a VM to detect known virtualization platforms. It may report one or more tags indicating the presence of virtualization. Use the output to write a series per tag as `virt_platform{type="<tag>"} 1`.

Update the dockerfile to have this script present. An init container can call this script to get the virtualization metrics generated into the current working directory.

/assign @pgier