### PR TITLE
Bug 1773243: If no virt platform is detected, set type to 'none'

### DIFF
--- a/text_collectors/virt.sh
+++ b/text_collectors/virt.sh
@@ -18,13 +18,17 @@ rm -f "${v}" || true
 touch "${v}"
 if [ -x /usr/sbin/virt-what ]
 then
-  echo '# HELP virt_platform reports one series per detected virtualization type' >>"${v}"
+  platforms="$( virt-what )"
+  echo '# HELP virt_platform reports one series per detected virtualization type. If no type is detected, the type is "none".' >>"${v}"
   echo '# TYPE virt_platform gauge' >>"${v}"
-  for platform in $( virt-what ); do
+  for platform in "${platforms}"; do
     if [[ -z "${platform}" ]]; then
       continue
     fi
     echo "virt_platform{type=\"${platform}\"} 1" >>"${v}"
   done
+  if [[ -z "${platforms}" ]]; then
+    echo "virt_platform{type=\"none\"} 1" >>"${v}"
+  fi
 fi
 mv "${v}" virt.prom


### PR DESCRIPTION
We will then be able to detect bare metal by the presence of none.

/assign @pgier 

Caught this while finishing out verification (bare metal tests were down all week).