### PR TITLE
Bug 1775454: virtwhat multiple platform

### DIFF
--- a/text_collectors/virt.sh
+++ b/text_collectors/virt.sh
@@ -18,10 +18,10 @@ rm -f "${v}" || true
 touch "${v}"
 if [ -x /usr/sbin/virt-what ]
 then
-  platforms="$( virt-what )"
+  platforms=$(echo $( virt-what ) | tr '\n' ' ')
   echo '# HELP virt_platform reports one series per detected virtualization type. If no type is detected, the type is "none".' >>"${v}"
   echo '# TYPE virt_platform gauge' >>"${v}"
-  for platform in "${platforms}"; do
+  for platform in ${platforms}; do
     if [[ -z "${platform}" ]]; then
       continue
     fi

--- a/text_collectors/virt.sh
+++ b/text_collectors/virt.sh
@@ -13,7 +13,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-v="${TMPDIR}/virt.working"
+v="${TMPDIR:-/tmp}/virt.working"
 rm -f "${v}" || true
 touch "${v}"
 if [ -x /usr/sbin/virt-what ]


### PR DESCRIPTION
Fix cases where virtwhat returns multiple detected platforms.
Also provide a default path to TMPDIR in case the environment var isn't set.