### PR TITLE
Disable cpu info metric on non x86 arches

### DIFF
--- a/collector/cpu_linux.go
+++ b/collector/cpu_linux.go
@@ -18,6 +18,7 @@ package collector
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -77,7 +78,7 @@ func NewCPUCollector() (Collector, error) {
 
 // Update implements Collector and exposes cpu related metrics from /proc/stat and /sys/.../cpu/.
 func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
-	if *enableCPUInfo {
+	if *enableCPUInfo && (runtime.GOARCH == "amd64") {
 		if err := c.updateInfo(ch); err != nil {
 			return err
 		}


### PR DESCRIPTION
On an IBM Z system it was observed that the parsecpuinfo function was crashing because the parsing of the CPU info is specific to x86 today - https://bugzilla.redhat.com/show_bug.cgi?id=1789260. For now, the short term fix is to disable cpu info metrics on non x86 arches and in the meanwhile we can work on the fix for supporting cpu info metric reporting for multi-arches.