### PR TITLE
Bug 1804012: On bare metal, detect system info

### DIFF
--- a/text_collectors/virt.sh
+++ b/text_collectors/virt.sh
@@ -48,7 +48,11 @@ then
   fi
 
   if [[ "${count}" -eq 0 ]]; then
-    echo "virt_platform{type=\"none\"} 1" >>"${v}"
+    line="$( printf 'virt_platform{type="none",bios_vendor="%q",bios_version="%q",system_manufacturer="%q",system_product_name="%q",system_version="%q",baseboard_manufacturer="%q",baseboard_product_name="%q"} 1' \
+      "$( dmidecode -s bios-vendor )" "$( dmidecode -s bios-version )" \
+      "$( dmidecode -s system-manufacturer )" "$( dmidecode -s system-product-name )" "$( dmidecode -s system-version )" \
+      "$( dmidecode -s baseboard-manufacturer )" "$( dmidecode -s baseboard-product-name )" )"
+    echo "${line//\\ / }" >>"${v}"
   fi
 fi
 mv "${v}" virt.prom


### PR DESCRIPTION
Gather bios, baseboard, and system product/vendor/version info to assist debugging failures in specific hardware configurations. Is only gathered on bare metal since virtual environments will not return meaningful info.

In practice I expect the cardinality of this to be <10 series for the vast majority of clusters.  I could imagine a few hodgepodge clusters, but the odds of a single large cluster having unique hardware for every node (on meaningful cluster sizes) is very small.  And a cluster with hundreds of unique hardware configurations would almost certainly be a very strong pathological signal.

/hold

while i test on baremetal