### PR TITLE
OWNERS: add component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
+component: "Monitoring"
+
 reviewers:
 - brancz
 - krasi-georgiev


### PR DESCRIPTION
This adds the monitoring component to the OWNERS file.

/cc @openshift/openshift-team-monitoring 