### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -8,7 +8,8 @@ FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \
       io.k8s.description="Prometheus exporter for machine metrics" \
       io.openshift.tags="prometheus,monitoring" \
-      maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+      summary="Prometheus exporter for machine metrics" \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
 
 COPY --from=builder /go/src/github.com/prometheus/node_exporter/node_exporter /bin/node_exporter
 


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value

/cc @openshift/openshift-team-monitoring