### PR TITLE
Updating golang-github-prometheus-node_exporter builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,10 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 
 WORKDIR /go/src/github.com/prometheus/node_exporter
 COPY . .
 RUN if yum install -y prometheus-promu; then export BUILD_PROMU=false; fi && make build
 
-FROM  registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.6
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-base-openshift
 LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \
       io.k8s.description="Prometheus exporter for machine metrics" \
       io.openshift.tags="prometheus,monitoring" \


### PR DESCRIPTION
Updating golang-github-prometheus-node_exporter builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/golang-github-prometheus-node_exporter.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.
