### PR TITLE
Bug 1906570: Capture the number of boots by reading wtmp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -14,7 +14,7 @@ LABEL io.k8s.display-name="OpenShift Prometheus Node Exporter" \
 COPY --from=builder /go/src/github.com/prometheus/node_exporter/node_exporter /bin/node_exporter
 
 RUN yum install -y virt-what && yum clean all && rm -rf /var/cache/*
-COPY text_collectors/virt.sh /node_exporter/collectors/init/
+COPY text_collectors/virt.sh text_collectors/boots.sh /node_exporter/collectors/init/
 
 EXPOSE      9100
 USER        nobody

--- a/text_collectors/boots.sh
+++ b/text_collectors/boots.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+#
+# Description: Expose metrics for number of boots of the system
+# Dependencies: none
+#
+# The script creates one metric series which is the number of recorded
+# boots in the /var/log/wtmp file. If wtmp is rotated, the next time the
+# node exporter is restarted it will recalculate the value, and may over
+# count restarts by one.
+#
+# Author: Clayton Coleman <smarterclayton@gmail.com>
+
+set -euo pipefail
+
+v="${TMPDIR:-/tmp}/boots.working"
+rm -f "${v}" || true
+touch "${v}"
+
+reboots=$( last reboot --time-format=iso -R | grep -cE '^reboot' )
+if [[ "${reboots}" -gt 0 ]]; then
+  echo '# HELP node_boots_total reports a single series which is the number of times this system has been booted excluding the current boot. If the value is zero, this is the first time the system has booted. The value is always non-negative.' >>"${v}"
+  echo '# TYPE node_boots_total counter' >>"${v}"
+  echo "node_boots_total{} $(( reboots - 1 ))" >>"${v}"
+fi
+
+mv "${v}" boots.prom

--- a/text_collectors/boots.sh
+++ b/text_collectors/boots.sh
@@ -13,9 +13,8 @@
 
 set -euo pipefail
 
-v="${TMPDIR:-/tmp}/boots.working"
-rm -f "${v}" || true
-touch "${v}"
+v=$(mktemp --suffix=.boots.working)
+chmod uga+r "${v}"
 
 reboots=$( last reboot --time-format=iso -R | grep -cE '^reboot' )
 if [[ "${reboots}" -gt 0 ]]; then

--- a/text_collectors/virt.sh
+++ b/text_collectors/virt.sh
@@ -13,9 +13,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-v="${TMPDIR:-/tmp}/virt.working"
-rm -f "${v}" || true
-touch "${v}"
+v=$(mktemp --suffix=.virt.working)
+chmod uga+r "${v}"
+
 if [ -x /usr/sbin/virt-what ]
 then
   platforms=$(echo $( virt-what ) | tr '\n' ' ')


### PR DESCRIPTION
This text collector reads from /var/log/wtmp (assumed mounted into
the proper spot) and outputs a metric for the number of reboots in
that log. On RHCOS utmp is automatically rotated.

Without https://github.com/openshift/cluster-monitoring-operator/pull/1017 wtmp is empty

![image](https://user-images.githubusercontent.com/1163175/101914683-9837f480-3b92-11eb-8791-b46cd1be80e6.png)

![image](https://user-images.githubusercontent.com/1163175/101915253-5bb8c880-3b93-11eb-802d-f1db3c612037.png)

During a cluster launch, we reboot once.  I then rebooted twice more.  The boots number excludes the current count, which ensures that when wtmp is rotated that we get a proper counter reset (machine that has node_boots 2 has 3 entries in wtmp including the current, then a rotation happens and they have 1 entry, so node_boots becomes 0, so the total boots is still 3 (2 + counter reset 0 + 1 current boot)

This allows us to estimate the disruption caused by system reboots.