### PR TITLE
OCPBUGS-1723: Fix a bug of metric format on AMD EPYC platforms

### DIFF
--- a/collector/rapl_linux.go
+++ b/collector/rapl_linux.go
@@ -80,7 +80,7 @@ func (c *raplCollector) Update(ch chan<- prometheus.Metric) error {
 		index := strconv.Itoa(rz.Index)
 
 		descriptor := prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "rapl", rz.Name+"_joules_total"),
+			prometheus.BuildFQName(namespace, "rapl", SanitizeMetricName(rz.Name+"_joules_total")),
 			"Current RAPL "+rz.Name+" value in joules",
 			[]string{"index", "path"}, nil,
 		)


### PR DESCRIPTION
This PR backports the fix to the release-4.11 branch

The PR to master branch:
https://github.com/openshift/node_exporter/pull/107

The original commit:
[rapl_collector: fix issue with invalid metric name (#2299)](https://github.com/prometheus/node_exporter/pull/2372/commits/0e320e725b5e2f9092b95f4d9f640ff08cf61683)

