### PR TITLE
MON-4077: Adding accelerators counter collector metric

### DIFF
--- a/collector/accelerators.go
+++ b/collector/accelerators.go
@@ -1,0 +1,137 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type cardData struct {
+	vendor string
+	model  string
+	id     string
+}
+
+type vendorData struct {
+	vendorName string
+	devicesIDs map[string]string
+}
+
+type acceleratorsCollector struct {
+	pciDevicesPath string
+	logger         log.Logger
+}
+
+func init() {
+	registerCollector("accelerator", defaultEnabled, NewAcceleratorCollector)
+}
+
+// NewAcceleratorCollector returns a new Collector exposing accelerator cards count.
+func NewAcceleratorCollector(logger log.Logger) (Collector, error) {
+	return &acceleratorsCollector{
+		pciDevicesPath: filepath.Join(*sysPath, "bus/pci/devices"),
+		logger:         logger,
+	}, nil
+}
+
+var (
+	acceleratorCardsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "accelerator", "card_info"),
+		"Accelerator card info including vendor, model and pci id (address)",
+		[]string{"vendor", "model", "id"}, nil,
+	)
+
+	nvidiaDeviceIDsMap = map[string]string{
+		"0x20b5": "A100",
+		"0x2230": "RTX_A6000",
+		"0x2717": "RTX_4090",
+		"0x2235": "A40",
+		"0x1df5": "V100",
+	}
+
+	// vendor map, add any new vendor to this map
+	vendorToDeviceMap = map[string]vendorData{
+		// nvidia devices
+		"0x10de": vendorData{"NVIDIA", nvidiaDeviceIDsMap},
+	}
+)
+
+func (a *acceleratorsCollector) Update(ch chan<- prometheus.Metric) error {
+	pciDevices, err := os.ReadDir(a.pciDevicesPath)
+	if err != nil {
+		return fmt.Errorf("failed to read from  %q: %w", a.pciDevicesPath, err)
+	}
+
+	for _, pciDevice := range pciDevices {
+		pciID := pciDevice.Name()
+		vendorID, err := a.getVendorID(pciID)
+		if err != nil {
+			level.Error(a.logger).Log("msg", "failed to get pci vendor ID", "name", pciDevice.Name(), "err", err)
+			continue
+		}
+		deviceID, err := a.getDeviceID(pciID)
+		if err != nil {
+			level.Error(a.logger).Log("msg", "failed to get pci device ID", "name", pciDevice.Name(), "err", err)
+			continue
+		}
+
+		level.Debug(a.logger).Log("msg", "checking pci device", "vendor", vendorID, "device", deviceID)
+
+		cardData, isMonitored := isMonitoredAccelerator(vendorID, deviceID, pciID)
+		if !isMonitored {
+			continue
+		}
+		level.Debug(a.logger).Log("msg", "accelerator device found", "vendor", cardData.vendor, "model", cardData.model)
+		ch <- prometheus.MustNewConstMetric(acceleratorCardsDesc, prometheus.CounterValue, float64(1), cardData.vendor, cardData.model, cardData.id)
+	}
+
+	return nil
+}
+
+func (a *acceleratorsCollector) getVendorID(pciID string) (string, error) {
+	return a.getPCIFileData(pciID, "vendor")
+}
+
+func (a *acceleratorsCollector) getDeviceID(pciID string) (string, error) {
+	return a.getPCIFileData(pciID, "device")
+}
+
+func (a *acceleratorsCollector) getPCIFileData(pciID, fileName string) (string, error) {
+	pciFilePath := filepath.Join(a.pciDevicesPath, pciID, fileName)
+	data, err := os.ReadFile(pciFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %s: %w", pciFilePath, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func isMonitoredAccelerator(vendor, device, pciID string) (cardData, bool) {
+	vendorData, ok := vendorToDeviceMap[vendor]
+	if !ok {
+		return cardData{}, false
+	}
+
+	deviceDesc, ok := vendorData.devicesIDs[device]
+	if !ok {
+		return cardData{}, false
+	}
+	return cardData{vendorData.vendorName, deviceDesc, pciID}, true
+}

--- a/collector/accelerators_test.go
+++ b/collector/accelerators_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+type testAcceleratorCollector struct {
+	xc Collector
+}
+
+func (c testAcceleratorCollector) Collect(ch chan<- prometheus.Metric) {
+	c.xc.Update(ch)
+}
+
+func (c testAcceleratorCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(c, ch)
+}
+
+func TestAccelerator(t *testing.T) {
+	testcase := `# HELP node_accelerator_card_info Accelerator card info including vendor, model and pci id (address)
+	# TYPE node_accelerator_card_info counter
+	node_accelerator_card_info{id="0000:00:02.0",model="A100",vendor="NVIDIA"} 1
+	node_accelerator_card_info{id="0000:00:09.0",model="A100",vendor="NVIDIA"} 1
+	node_accelerator_card_info{id="0000:00:1f.5",model="RTX_4090",vendor="NVIDIA"} 1
+	`
+
+	*sysPath = "fixtures/sys"
+
+	logger := log.NewLogfmtLogger(os.Stderr)
+	c, err := NewAcceleratorCollector(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(&testAcceleratorCollector{xc: c})
+
+	sink := make(chan prometheus.Metric)
+	go func() {
+		err = c.Update(sink)
+		if err != nil {
+			panic(fmt.Errorf("failed to update collector: %s", err))
+		}
+		close(sink)
+	}()
+
+	err = testutil.GatherAndCompare(reg, strings.NewReader(testcase))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/collector/fixtures/sys.ttar
+++ b/collector/fixtures/sys.ttar
@@ -35,6 +35,77 @@ SymlinkTo: ../../../devices/system/node/node0
 Path: sys/bus/node/devices/node1
 SymlinkTo: ../../../devices/system/node/node1
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci/devices
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci/devices/0000:00:00.0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:00.0/device
+Lines: 1
+0x7896
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:00.0/vendor
+Lines: 1
+0x4565
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci/devices/0000:00:02.0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:02.0/device
+Lines: 1
+0x20b5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:02.0/vendor
+Lines: 1
+0x10de
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci/devices/0000:00:07.0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:07.0/device
+Lines: 1
+0x2344
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:07.0/vendor
+Lines: 1
+0x6565
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci/devices/0000:00:09.0
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:09.0/device
+Lines: 1
+0x20b5
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:09.0/vendor
+Lines: 1
+0x10de
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Directory: sys/bus/pci/devices/0000:00:1f.5
+Mode: 755
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:1f.5/device
+Lines: 1
+0x2717
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+Path: sys/bus/pci/devices/0000:00:1f.5/vendor
+Lines: 1
+0x10de
+Mode: 644
+# ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 Directory: sys/class
 Mode: 755
 # ttar - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
The new collector counts the number of accelerator PCI device on the node, and creates a new counter metric based on the accelerator type. The acelerators are collected based on the vendor id and device id predefined in a map. The metric contains a label (type) per each accelerator version. Adding new accelerator(s) requires just updating/creating new vendorID/deviceID map, without additional changes to the code