### PR TITLE
MGMT-19498:Add configmap support to the accelerator's collector

### DIFF
--- a/collector/accelerators.go
+++ b/collector/accelerators.go
@@ -19,10 +19,21 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"gopkg.in/yaml.v2"
 )
+
+type vendorModels struct {
+	VendorName string `yaml:"vendorName"`
+	VendorID   string `yaml:"vendorID"`
+	Models     []struct {
+		PciID     string `yaml:"pciID"`
+		ModelName string `yaml:"modelName"`
+	} `yaml:"models"`
+}
 
 type cardData struct {
 	vendor string
@@ -36,9 +47,20 @@ type vendorData struct {
 }
 
 type acceleratorsCollector struct {
-	pciDevicesPath string
-	logger         log.Logger
+	pciDevicesPath    string
+	logger            log.Logger
+	vendorToDeviceMap map[string]vendorData
 }
+
+var (
+	mappingFile = kingpin.Flag("collector.accelerators.mapping-file", "Path to the mapped accelerators data config.").Default(
+		"/var/node_exporter/accelerators_collector_config/config.yaml").String()
+	acceleratorCardsDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "accelerator", "card_info"),
+		"Accelerator card info including vendor, model and pci id (address)",
+		[]string{"vendor", "model", "id"}, nil,
+	)
+)
 
 func init() {
 	registerCollector("accelerator", defaultEnabled, NewAcceleratorCollector)
@@ -46,97 +68,16 @@ func init() {
 
 // NewAcceleratorCollector returns a new Collector exposing accelerator cards count.
 func NewAcceleratorCollector(logger log.Logger) (Collector, error) {
+	vendorToDeviceMap, err := prepareVendorModelData(*mappingFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get the accelerator configuration: %v", err)
+	}
 	return &acceleratorsCollector{
-		pciDevicesPath: filepath.Join(*sysPath, "bus/pci/devices"),
-		logger:         logger,
+		pciDevicesPath:    filepath.Join(*sysPath, "bus/pci/devices"),
+		logger:            logger,
+		vendorToDeviceMap: vendorToDeviceMap,
 	}, nil
 }
-
-var (
-	acceleratorCardsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(namespace, "accelerator", "card_info"),
-		"Accelerator card info including vendor, model and pci id (address)",
-		[]string{"vendor", "model", "id"}, nil,
-	)
-
-	nvidiaDeviceIDsMap = map[string]string{
-		"0x20f5": "NVIDIA A800 PCIe 80GB",
-		"0x20f6": "NVIDIA A800 40GB PCIe active cooled",
-		"0x20fd": "NVIDIA AX800",
-		"0x20f1": "NVIDIA A100 PCIe 40GB",
-		"0x20b5": "NVIDIA A100 PCIe 80GB",
-		"0x2235": "NVIDIA A40",
-		"0x20b7": "NVIDIA A30",
-		"0x2236": "NVIDIA A10",
-		"0x25b6": "NVIDIA A16",
-		"0x2322": "H800 NVL",
-		"0x2321": "NVIDIA H100 NVL",
-		"0x2331": "NVIDIA H100 PCIe 80GB",
-		"0x26b5": "NVIDIA L40",
-		"0x26b9": "NVIDIA L40S",
-		"0x26bA": "NVIDIA L20 liquid cooled",
-		"0x27b8": "NVIDIA L4",
-		"0x27b6": "NVIDIA L2",
-		"0x26b1": "NVIDIA RTX 6000 Ada",
-		"0x26b3": "NVIDIA RTX 5880 Ada",
-		"0x2231": "NVIDIA RTX 5000 Ada",
-		"0x2230": "NVIDIA RTX A6000",
-		"0x2233": "NVIDIA RTX A5500",
-		"0x1e30": "NVIDIA RTX 8000 passive",
-		"0x2531": "NVIDIA RTX A2000",
-		"0x20b0": "NVIDIA A100 SXM4 40G",
-		"0x233a": "NVIDIA H800 NVL",
-		"0x233b": "NVIDIA H200 NVL",
-		"0x20b2": "NVIDIA A100SXM4 80GB",
-		"0x20b3": "NVIDIA A100 SXM 64GB",
-		"0x20bd": "NVIDIA A800 SXM4 40GB",
-		"0x20f3": "NVIDIA A800 SXM4 80GB",
-		"0x25b0": "NVIDIA RTX A1000",
-	}
-
-	amdDeviceIDsMap = map[string]string{
-		"0x740f": "AMD MI210",
-		"0x740c": "AMD MI250",
-		"0x7408": "AMD MI250X",
-		"0x74a0": "AMD MI300",
-		"0x74a1": "AMD MI300X",
-		"0x74a5": "AMD MI325X",
-		"0x7aa2": "AMD MI308X",
-		"0x74b5": "AMD MI300X VF",
-		"0x7410": "AMD MI210 VF",
-	}
-
-	gaudiDeviceIDsMap = map[string]string{
-		"0x1000": "Gaudi 1",
-		"0x1020": "Gaudi 2",
-	}
-
-	intelDeviceIDsMap = map[string]string{
-		"0x0bd5": "Intel Data Center GPU Max 1550",
-		"0x0bda": "Intel Data Center GPU Max 1100",
-		"0x56c0": "Intel Data Center GPU Flex 170",
-		"0x56c1": "Intel Data Center GPU Flex 140",
-	}
-
-	qualcommDeviceIDsMap = map[string]string{
-		"0xa100": "Qualcomm AI 100",
-		"0xa080": "Qualcomm AI 80",
-	}
-
-	// vendor map, add any new vendor to this map
-	vendorToDeviceMap = map[string]vendorData{
-		// nvidia devices
-		"0x10de": vendorData{"NVIDIA", nvidiaDeviceIDsMap},
-		// amd devices
-		"0x1002": vendorData{"AMD", amdDeviceIDsMap},
-		// gaudi devices
-		"0x1da3": vendorData{"GAUDI", gaudiDeviceIDsMap},
-		// intel devices
-		"0x8086": vendorData{"INTEL", intelDeviceIDsMap},
-		// qualcomm devices
-		"0x17cb": vendorData{"QUALCOMM", qualcommDeviceIDsMap},
-	}
-)
 
 func (a *acceleratorsCollector) Update(ch chan<- prometheus.Metric) error {
 	pciDevices, err := os.ReadDir(a.pciDevicesPath)
@@ -159,7 +100,7 @@ func (a *acceleratorsCollector) Update(ch chan<- prometheus.Metric) error {
 
 		level.Debug(a.logger).Log("msg", "checking pci device", "vendor", vendorID, "device", deviceID)
 
-		cardData, isMonitored := isMonitoredAccelerator(vendorID, deviceID, pciID)
+		cardData, isMonitored := a.isMonitoredAccelerator(vendorID, deviceID, pciID)
 		if !isMonitored {
 			continue
 		}
@@ -187,8 +128,8 @@ func (a *acceleratorsCollector) getPCIFileData(pciID, fileName string) (string, 
 	return strings.TrimSpace(string(data)), nil
 }
 
-func isMonitoredAccelerator(vendor, device, pciID string) (cardData, bool) {
-	vendorData, ok := vendorToDeviceMap[vendor]
+func (a *acceleratorsCollector) isMonitoredAccelerator(vendor, device, pciID string) (cardData, bool) {
+	vendorData, ok := a.vendorToDeviceMap[vendor]
 	if !ok {
 		return cardData{}, false
 	}
@@ -198,4 +139,37 @@ func isMonitoredAccelerator(vendor, device, pciID string) (cardData, bool) {
 		return cardData{}, false
 	}
 	return cardData{vendorData.vendorName, deviceDesc, pciID}, true
+}
+
+func prepareVendorModelData(mappingFilePath string) (map[string]vendorData, error) {
+	yamlStr, err := os.ReadFile(mappingFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open accelerators config file %s: %v", mappingFilePath, err)
+	}
+	var vendorsModelsConfig []vendorModels
+	err = yaml.UnmarshalStrict(yamlStr, &vendorsModelsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal accelerators config data: %v", err)
+	}
+	vendorToDeviceMap := make(map[string]vendorData, len(vendorsModelsConfig))
+
+	for _, vendorModelsConfig := range vendorsModelsConfig {
+		if _, ok := vendorToDeviceMap[vendorModelsConfig.VendorID]; ok {
+			return nil, fmt.Errorf("mapping file contains duplicate of vendor id %s", vendorModelsConfig.VendorID)
+		}
+		devicesIDs := make(map[string]string, len(vendorModelsConfig.Models))
+		for _, model := range vendorModelsConfig.Models {
+			if _, ok := devicesIDs[model.PciID]; ok {
+				return nil, fmt.Errorf("mapping file contains duplicate of device id %s for vendor id %s", model.PciID, vendorModelsConfig.VendorID)
+			}
+			devicesIDs[model.PciID] = model.ModelName
+		}
+		vendorToDeviceMap[vendorModelsConfig.VendorID] = vendorData{
+			vendorName: vendorModelsConfig.VendorName,
+			devicesIDs: devicesIDs,
+		}
+
+	}
+
+	return vendorToDeviceMap, nil
 }

--- a/collector/testdata/accelerators_test_data.yaml
+++ b/collector/testdata/accelerators_test_data.yaml
@@ -1,0 +1,23 @@
+- vendorName: NVIDIA
+  vendorID: 0x10de
+  models:
+  - pciID: 0x20b5
+    modelName: A100
+  - pciID: 0x2230
+    modelName: RTX_A6000
+  - pciID: 0x2717
+    modelName: RTX_4090
+  - pciID: 0x2235
+    modelName: A40
+  - pciID: 0x1df5
+    modelName: V100
+  - pciID: 0x20f1
+    modelName: A100 40G
+- vendorName: AMD
+  vendorID: 0x1002
+  models:
+  - pciID: 0x740f
+    modelName: MI210
+  - pciID: 0x740c
+    modelName: MI250
+

--- a/collector/testdata/accelerators_test_data_duplicated_device_ids.bad.yaml
+++ b/collector/testdata/accelerators_test_data_duplicated_device_ids.bad.yaml
@@ -1,0 +1,23 @@
+- vendorName: NVIDIA
+  vendorID: 0x10de
+  models:
+  - pciID: 0x20b5
+    modelName: A100
+  - pciID: 0x2230
+    modelName: RTX_A6000
+  - pciID: 0x2717
+    modelName: RTX_4090
+  - pciID: 0x2235
+    modelName: A40
+  - pciID: 0x2235
+    modelName: V100
+  - pciID: 0x20f1
+    modelName: A100 40G
+- vendorName: AMD
+  vendorID: 0x1002
+  models:
+  - pciID: 0x740f
+    modelName: MI210
+  - pciID: 0x740c
+    modelName: MI250
+

--- a/collector/testdata/accelerators_test_data_duplicated_vendors.bad.yaml
+++ b/collector/testdata/accelerators_test_data_duplicated_vendors.bad.yaml
@@ -1,0 +1,23 @@
+- vendorName: NVIDIA
+  vendorID: 0x10de
+  models:
+  - pciID: 0x20b5
+    modelName: A100
+  - pciID: 0x2230
+    modelName: RTX_A6000
+  - pciID: 0x2717
+    modelName: RTX_4090
+  - pciID: 0x2235
+    modelName: A40
+  - pciID: 0x1df5
+    modelName: V100
+  - pciID: 0x20f1
+    modelName: A100 40G
+- vendorName: AMD
+  vendorID: 0x10de
+  models:
+  - pciID: 0x740f
+    modelName: MI210
+  - pciID: 0x740c
+    modelName: MI250
+

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/safchain/ethtool v0.3.0
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	golang.org/x/sys v0.19.0
+	gopkg.in/yaml.v2 v2.4.0
 	howett.net/plist v1.0.1
 )
 
@@ -57,5 +58,4 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
accelerator collector needs to have a configuration that describes which vendors and models it should collect. This PR add loading that data from a file. Eventually this file be a configmap mapped into the node-exporter pod.
Parsing the configmap file is done in the init function. The file is defined by an environment variable. This variable will be configured by CMO and by unit-test