### PR TITLE
OCPBUGS-83863: Strip debug symbols from Go binaries

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -8,6 +8,7 @@ build:
     binaries:
         - name: node_exporter
     ldflags: |
+        -s -w
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}
         -X github.com/prometheus/common/version.Branch={{.Branch}}


### PR DESCRIPTION
## Summary
- Add `-s -w` to ldflags in `.promu.yml` to strip DWARF debug info and symbol tables

## Impact
The prometheus-node-exporter image (323 MB) contains one unstripped Go binary:
- `node_exporter` (23.2 MB)

Stripping typically reduces Go binary size by 20-30%, reducing container image pull time during node scale-up.

## Test plan
- [ ] Verify image builds successfully
- [ ] Verify binary is stripped
- [ ] Verify node_exporter functions correctly